### PR TITLE
Uses uname -m instead of arch

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -19,7 +19,7 @@ RELEASE_DATE=$(date '+%Y-%m-%d')
 TAG_ROOT="flipstone/haskell-tools:debian-unstable-ghc-9.2.5-$RELEASE_DATE-$COMMIT_SHA"
 ARM_TAG="$TAG_ROOT"-arm64
 AMD_TAG="$TAG_ROOT"-amd64
-ARCH=$(arch)
+ARCH=$(uname -m)
 
 case "$ARCH" in
   x86_64)


### PR DESCRIPTION
"arch" is not always installed with the coreutils packages so it's a
safer bet to rely on "uname -m" from the same package since it's essentially univeral.

The "arch" docs since it is equivalent to "uname -m".
