### PR TITLE
Sets the base to `stable`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:unstable-20230703-slim
+FROM debian:stable-20230814-slim
 
 ENV LANG="C.UTF-8" LANGUAGE="C.UTF-8" LC_ALL="C.UTF-8"
 
@@ -12,7 +12,7 @@ ADD install-tools.sh /install-tools.sh
 RUN apt-get update \
     && apt-get install -qq -y --no-install-recommends \
         curl build-essential git-all libffi-dev libffi8 libgmp-dev \
-        libgmp10 libncurses-dev libncurses5 libtinfo5 zlib1g-dev openssh-client \
+        libgmp10 libncurses-dev libncurses6 libtinfo6 zlib1g-dev openssh-client \
         procps libnuma-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH="/usr/local/.ghcup/bin:$PATH"
 
 RUN ghcup install stack 2.11.1 --set
 RUN ghcup install ghc 9.4.6 --set
-RUN ghcup install hls 2.1.0.0 --set
+RUN ghcup install hls 2.2.0.0 --set
 
 ADD stack.yaml /stack.yaml
 RUN /bin/sh /install-tools.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,9 @@ RUN /bin/sh /get-ghcup.sh
 
 ENV PATH="/usr/local/.ghcup/bin:$PATH"
 
-RUN ghcup install cabal 3.10.1.0 --set
 RUN ghcup install stack 2.11.1 --set
-RUN ghcup install ghc 9.4.5 --set
-RUN ghcup install hls 2.0.0.0 --set
+RUN ghcup install ghc 9.4.6 --set
+RUN ghcup install hls 2.1.0.0 --set
 
 ADD stack.yaml /stack.yaml
 RUN /bin/sh /install-tools.sh

--- a/build-image.sh
+++ b/build-image.sh
@@ -16,7 +16,7 @@ esac
 
 
 RELEASE_DATE=$(date '+%Y-%m-%d')
-TAG_ROOT="ghcr.io/flipstone/haskell-tools:debian-unstable-ghc-9.4.5-$RELEASE_DATE-$COMMIT_SHA"
+TAG_ROOT="ghcr.io/flipstone/haskell-tools:debian-stable-ghc-9.4.6-$RELEASE_DATE-$COMMIT_SHA"
 ARM_TAG="$TAG_ROOT"-arm64
 AMD_TAG="$TAG_ROOT"-amd64
 ARCH=$(uname -m)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
 system-ghc: true
 install-ghc: false
-resolver: lts-21.3
+resolver: lts-21.9
 packages: []
 extra-deps:
   - hlint-3.6.1
-  - weeder-2.6.0
+  - weeder-2.7.0
   - fourmolu-0.13.1.0
   - Cabal-syntax-3.10.1.0
   - ghc-lib-parser-9.6.2.20230523


### PR DESCRIPTION
Due to problems with the latest versions of packages in `unstable`, we have set the base to `stable`.