### PR TITLE
Adds stan and a wrapping script to run it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && apt-get install -qq -y --no-install-recommends \
         curl build-essential git-all libffi-dev libffi8 libgmp-dev \
         libgmp10 libncurses-dev libncurses6 libtinfo6 zlib1g-dev openssh-client \
-        procps libnuma-dev pkg-config \
+        procps libnuma-dev pkg-config jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,3 +46,5 @@ ADD stack.yaml /stack.yaml
 
 ADD install-tools.sh /install-tools.sh
 RUN /bin/sh /install-tools.sh
+
+ADD run-stan.sh /usr/local/bin/run-stan

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -17,6 +17,7 @@ stack install \
   fourmolu \
   ghcid \
   hlint \
-  ShellCheck
+  ShellCheck \
+  stan
 
 rm -rf .stack-work /root/.stack

--- a/run-stan.sh
+++ b/run-stan.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+echo "Running stan..."
+
+REPORT=$(stan report --json-output)
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "$REPORT"
+  exit $EXIT_CODE
+fi
+
+set -o errexit
+
+OBSERVATIONS=$(echo "$REPORT" | jq '.observations')
+LENGTH=$(echo "$OBSERVATIONS" | jq length)
+
+if [ "$LENGTH" -gt 0 ]; then
+  echo "stan found the following problems:"
+  echo "$OBSERVATIONS" | jq -r '.[] | "- \(.inspectionId): \(.srcSpan)"'
+  echo "See stan.html or run 'stan' for more information."
+  exit 1
+else
+  echo "stan found no problems."
+fi

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,16 @@ install-ghc: false
 resolver: lts-22.39
 packages: []
 extra-deps:
-  - weeder-2.9.0
+- weeder-2.9.0
+- github: kowainik/stan
+  commit: 386a5efa1ce4ad6c83b083d3d47fcb664abffd36
+# Extra deps for stan
+- ansi-wl-pprint-0.6.9
+- dir-traverse-0.2.3.0
+- extensions-0.1.0.1
+- optparse-applicative-0.17.1.0
+- tomland-1.3.3.3
+- trial-0.0.0.0
+- trial-optparse-applicative-0.0.0.0
+- trial-tomland-0.0.0.0
+- validation-selective-0.2.0.0


### PR DESCRIPTION
stan doesn't come with a way to produce a non-zero exit code when it finds issues, so I added a wrapping script that runs `stan report --json-output`, which saves an HTML report and outputs the report as JSON. The script will inspect the JSON and exit with 1 if there are any problems reported.