### PR TITLE
Correctly handles stan exit codes

### DIFF
--- a/run-stan.sh
+++ b/run-stan.sh
@@ -5,21 +5,30 @@ echo "Running stan..."
 REPORT=$(stan report --json-output "$@")
 EXIT_CODE=$?
 
-if [ "$EXIT_CODE" -ne 0 ]; then
-  echo "$REPORT"
-  exit $EXIT_CODE
-fi
-
 set -o errexit
 
-OBSERVATIONS=$(echo "$REPORT" | jq '.observations')
-LENGTH=$(echo "$OBSERVATIONS" | jq length)
+OBSERVATIONS=$(echo "$REPORT" | jq -R 'try fromjson | .observations')
 
-if [ "$LENGTH" -gt 0 ]; then
-  echo "stan found the following problems:"
-  echo "$OBSERVATIONS" | jq -r '.[] | "- \(.inspectionId): \(.srcSpan)"'
-  echo "See stan.html or run 'stan' for more information."
-  exit 1
+if [ -n "$OBSERVATIONS" ]; then
+  LENGTH=$(echo "$OBSERVATIONS" | jq 'length')
+
+  if [ "$LENGTH" -gt 0 ]; then
+    echo "stan found the following problems:"
+    echo "$OBSERVATIONS" | jq -r '.[] | "- \(.inspectionId): \(.srcSpan)"'
+    echo "See stan.html or run 'stan' for more information."
+    exit 1
+  else
+    echo "stan found no problems."
+    exit 0
+  fi
 else
-  echo "stan found no problems."
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "stan command failed with the following output:"
+    echo "$REPORT"
+    exit "$EXIT_CODE"
+  else
+    echo "Unexpected output from stan:"
+    echo "$REPORT"
+    exit 1
+  fi
 fi


### PR DESCRIPTION
It turns out that `stan` will exit with 1 when it has an observation with the "Error" severity. I refactored the script to account for this.