### PR TITLE
Build without publishing on Dependabot branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,16 @@ name: Build and push docker image
 on:
   push:
 
+# packages:write is needed to push images and layer caches to ghcr on
+# regular runs. Dependabot-triggered runs only build (no pushes) and get a
+# read-only GITHUB_TOKEN regardless of what is declared here unless
+# permissions are explicit; declaring them also gives those runs the ghcr
+# read access their cache pulls need. (Dependabot runs read the DOCKERHUB_*
+# secrets from the separate Dependabot secrets store — see README.md.)
+permissions:
+  contents: read
+  packages: write
+
 defaults:
   run:
     shell: bash
@@ -72,11 +82,23 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build And Push Image
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: |
           ./scripts/build-image.sh build-and-push-arch-tag
 
+      # Dependabot bumps should verify that the image still builds (reusing
+      # the registry layer cache, so actions-only bumps are cheap) without
+      # publishing anything.
+      - name: Build Image without pushing (Dependabot)
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        run: |
+          ./scripts/build-image.sh build-arch-tag
+
   build_and_push_manifest:
     name: Build manifest docker image
+    # Dependabot runs build without pushing, so there are no arch tags to
+    # scan or to assemble into a manifest.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on:
       group: ci-lite
       labels: [self-hosted, ci-lite]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ docker compose run --rm hadolint hadolint Dockerfile
 
 Hadolint configuration (ignored rules) lives in `.hadolint.yaml`.
 
+# Dependabot
+
+Dependabot bumps the base image digest and the GitHub Actions versions
+monthly. CI runs on Dependabot branches verify that both arch images still
+build (using the registry layer cache) but publish nothing: the image push,
+scan, and manifest steps are skipped.
+
+Workflows triggered by Dependabot read secrets from the separate
+Dependabot secrets store (repo Settings > Secrets and variables >
+Dependabot), so `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` must be
+configured there as well as in Actions secrets — otherwise the Docker Hub
+and dhi.io logins fail on every Dependabot PR. The same two secrets also
+let Dependabot authenticate to dhi.io for base image digest updates (see
+`.github/dependabot.yaml`).
+
 # How to build this for release
 
 Once you push to GitHub (either on a branch or main), the GitHub workflow

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -73,6 +73,16 @@ case $COMMAND in
       --push
     ;;
 
+  build-arch-tag)
+    set_build_args
+    set_tag_and_arch_variables
+    echo "Building $ARCH_TAG without pushing (verification only)"
+    docker buildx build . \
+      "${BUILD_ARGS[@]}" \
+      --tag "$ARCH_TAG" \
+      --cache-from type=registry,ref="$CACHE_TAG"
+    ;;
+
   push-manifest)
     set_tag_and_arch_variables
     echo "Both $AMD_TAG and $ARM_TAG must be pushed to GitHub Container Registry BEFORE running this step."
@@ -91,6 +101,6 @@ case $COMMAND in
     docker compose run --rm trivy image "$AMD_TAG" | tee trivy-reports/amd64.txt
     ;;
   *)
-    echo "usage: ./scripts/build-image.sh build-local-beta|build-and-push-arch-tag|push-manifest|scan-local-beta|scan-amd64-tag"
+    echo "usage: ./scripts/build-image.sh build-local-beta|build-arch-tag|build-and-push-arch-tag|push-manifest|scan-local-beta|scan-amd64-tag"
     exit 1
 esac;


### PR DESCRIPTION
Dependabot bumps should prove the image still builds, not publish it. Add a build-arch-tag command that builds with the registry layer cache but no --push and no cache write, run it instead of build-and-push-arch-tag when the actor is dependabot[bot], and skip the scan/manifest job entirely since there are no pushed arch tags to scan or assemble. Actions-version bumps rebuild almost nothing thanks to the layer cache; base digest bumps do a full build, which is exactly the verification they need.